### PR TITLE
Permissions fix, profile image added options

### DIFF
--- a/Tinytalefactory/profile/views.py
+++ b/Tinytalefactory/profile/views.py
@@ -1,15 +1,12 @@
 from django.views import generic as views
+from django.contrib.auth.mixins import LoginRequiredMixin
 import os
 
 
-class ProfileView(views.TemplateView):
+class ProfileView(LoginRequiredMixin, views.TemplateView):
     template_name = 'profile/profile.html'
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['paypal_id'] = os.getenv('PAYPAL_CLIENT_ID')
         return context
-
-
-
-

--- a/staticfiles/css/profile/profile.css
+++ b/staticfiles/css/profile/profile.css
@@ -83,6 +83,10 @@
     width: 100%;
 }
 
+.profile-image-container img:hover {
+    cursor: pointer;
+}
+
 .settings-options-wrapper {
     display: none;
     flex-wrap: wrap;

--- a/staticfiles/js/profile/profileImageChangeScript.js
+++ b/staticfiles/js/profile/profileImageChangeScript.js
@@ -1,0 +1,22 @@
+const imgEl = document.querySelector('.profile-image-container img');
+
+imgEl.addEventListener('click', (e) => changeImage(e));
+
+const imageUrls = [
+    'https://res.cloudinary.com/dh7ur0uv3/image/upload/t_profile-pic-ttf/v1731072029/cat1_wl5bfj.webp',
+    'https://res.cloudinary.com/dh7ur0uv3/image/upload/t_profile-pic-ttf/v1731072370/cat2_arnkxb.webp',
+    'https://res.cloudinary.com/dh7ur0uv3/image/upload/t_profile-pic-ttf/v1731072371/cat3_dxr6ek.webp',
+    'https://res.cloudinary.com/dh7ur0uv3/image/upload/t_profile-pic-ttf/v1731072371/cat4_s6nwvb.jpg',
+    'https://res.cloudinary.com/dh7ur0uv3/image/upload/t_profile-pic-ttf/v1731072405/cat5_xmxrvm.webp',
+]
+
+function changeImage(e) {
+    const max = imageUrls.length - 1;
+    const min = 0;
+    const randomIndex = Math.floor(Math.random() * (max - min + 1)) + min;
+
+    imgEl.setAttribute('src', imageUrls[randomIndex]);
+}
+
+changeImage();
+

--- a/templates/profile/profile.html
+++ b/templates/profile/profile.html
@@ -102,6 +102,7 @@
     <script src="{% static 'js/profile/profileOptions.js' %}"></script>
     <script src="{% static 'js/profile/paypalScript.js' %}"></script>
     <script src="{% static 'js/profile/profileScript.js' %}"></script>
+    <script src="{% static 'js/profile/profileImageChangeScript.js' %}"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             document.querySelector('body').classList.add('profile-page-background');


### PR DESCRIPTION
- Fixed permission issue with generate stories where user email was taken from auth_user model, instead of account_emailaddress model
- Added LoginRequiredMixin for the profile page, which was missing
- Added a few options for profile image, where users get a random cat picture as profile image every time they go to profile page, every time they click on the image, it gives them another random pic.